### PR TITLE
add `synchronize` to the activity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
       - ready_for_review
 
 jobs:


### PR DESCRIPTION
Firstly I thought that you would _not_ need to run this workflow when the event is of `synchronize` type. But I found that when force-pushing some commit to your repository, previous results of the status checks become invalid, so you have to make some useless editing your PR description to re-run the check to pass.

So `synchronize` is desirable...